### PR TITLE
DateTime Parse Fix for Java repo

### DIFF
--- a/IoTHubManager/DevicePropertiesTest.cs
+++ b/IoTHubManager/DevicePropertiesTest.cs
@@ -1,9 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Net;
-using System.Text;
 using System.Threading;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Xunit;
 
@@ -33,7 +32,10 @@ namespace IoTHubManager
             var response = this.Request.Post(device);
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
-            this.device = JObject.Parse(response.Content);
+            this.device = JsonConvert.DeserializeObject(response.Content, new JsonSerializerSettings
+            {
+                DateParseHandling = DateParseHandling.None
+            }) as JObject;
             this.deviceId = this.device["Id"].ToString();
         }
 


### PR DESCRIPTION
# Description and Motivation <!-- Info & Context so we can review your pull request -->
DateTime Parse Fix for Java repo
Java repo is unable to parse LastActivity and LastStatusUpdated because, integration test is changing their format.
...

# Change type <!-- [x] in all the boxes that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Breaking change (breaks backward compatibility)

**Checklist:**

- [ ] All tests passed
- [ ] The code follows the code style and conventions of this project
- [ ] The change requires a change to the documentation
- [ ] I have updated the documentation accordingly
